### PR TITLE
feat(api): add random question endpoint

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,16 @@ function createApp(db) {
     });
   });
 
+  app.get('/api/questions/random', (req, res) => {
+    const count = Math.max(parseInt(req.query.count, 10) || 1, 1);
+    db.all('SELECT * FROM questions ORDER BY RANDOM() LIMIT ?', [count], (err, rows) => {
+      if (err) {
+        return res.status(500).json({ error: err.message });
+      }
+      res.json(rows);
+    });
+  });
+
   app.get('/api/questions/:id', (req, res) => {
     db.get('SELECT * FROM questions WHERE id = ?', [req.params.id], (err, row) => {
       if (err) {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -59,3 +59,20 @@ test('GET /api/questions returns questions', async () => {
   expect(res.body.length).toBeGreaterThan(0);
   expect(res.body[0]).toHaveProperty('question');
 });
+
+test('GET /api/questions/random returns one question by default', async () => {
+  const res = await request(app).get('/api/questions/random');
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  expect(res.body.length).toBe(1);
+  expect(res.body[0]).toHaveProperty('question');
+});
+
+test('GET /api/questions/random?count=2 returns two random questions', async () => {
+  const res = await request(app).get('/api/questions/random?count=2');
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  expect(res.body.length).toBe(2);
+  const ids = res.body.map((q) => q.id);
+  expect(new Set(ids).size).toBe(2);
+});


### PR DESCRIPTION
## Summary
- add `/api/questions/random` API for fetching random question(s)
- support `count` query to limit random selection
- test new API behaviors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1693e937c832cb6c67dae679ca2b8