### PR TITLE
feat: add answer checking endpoint

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 
 function createApp(db) {
   const app = express();
+  app.use(express.json());
 
   app.get('/api/questions', (req, res) => {
     db.all('SELECT * FROM questions', [], (err, rows) => {
@@ -32,6 +33,33 @@ function createApp(db) {
       }
       res.json(row);
     });
+  });
+
+  app.post('/api/questions/:id/answer', (req, res) => {
+    const { answer } = req.body;
+    if (!answer) {
+      return res.status(400).json({ error: 'Answer is required' });
+    }
+
+    db.get(
+      'SELECT correct, explanation, reference FROM questions WHERE id = ?',
+      [req.params.id],
+      (err, row) => {
+        if (err) {
+          return res.status(500).json({ error: err.message });
+        }
+        if (!row) {
+          return res.status(404).json({ error: 'Not found' });
+        }
+
+        const isCorrect = row.correct === answer;
+        res.json({
+          correct: isCorrect,
+          explanation: row.explanation,
+          reference: row.reference
+        });
+      }
+    );
   });
 
   return app;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -76,3 +76,21 @@ test('GET /api/questions/random?count=2 returns two random questions', async () 
   const ids = res.body.map((q) => q.id);
   expect(new Set(ids).size).toBe(2);
 });
+
+test('POST /api/questions/:id/answer returns correct true for right answer', async () => {
+  const res = await request(app)
+    .post('/api/questions/1/answer')
+    .send({ answer: 'optionA' });
+  expect(res.status).toBe(200);
+  expect(res.body.correct).toBe(true);
+  expect(res.body).toHaveProperty('explanation');
+});
+
+test('POST /api/questions/:id/answer returns correct false for wrong answer', async () => {
+  const res = await request(app)
+    .post('/api/questions/1/answer')
+    .send({ answer: 'optionB' });
+  expect(res.status).toBe(200);
+  expect(res.body.correct).toBe(false);
+  expect(res.body).toHaveProperty('explanation');
+});


### PR DESCRIPTION
## Summary
- parse JSON bodies in Express app
- add POST `/api/questions/:id/answer` endpoint to validate answers and return explanations
- test new endpoint for correct and incorrect answers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c169ebd8b0832c8949aef22b8edb78