### PR TITLE
Add web interface for quiz app

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SC-200 Quiz</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    .option { display: block; margin: 8px 0; }
+    #result { margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h1>SC-200 Quiz</h1>
+  <div id="question-container">
+    <p id="question">Loading...</p>
+    <div id="options"></div>
+    <button id="submit">Submit Answer</button>
+  </div>
+  <div id="result"></div>
+
+  <script>
+    let currentQuestion;
+    async function loadQuestion() {
+      const res = await fetch('/api/questions/random');
+      const [question] = await res.json();
+      currentQuestion = question;
+      document.getElementById('question').textContent = question.question;
+      const optionsDiv = document.getElementById('options');
+      optionsDiv.innerHTML = '';
+      ['optionA','optionB','optionC','optionD'].forEach((key) => {
+        if (question[key]) {
+          const label = document.createElement('label');
+          label.className = 'option';
+          const radio = document.createElement('input');
+          radio.type = 'radio';
+          radio.name = 'answer';
+          radio.value = key;
+          label.appendChild(radio);
+          label.appendChild(document.createTextNode(question[key]));
+          optionsDiv.appendChild(label);
+        }
+      });
+    }
+
+    document.getElementById('submit').addEventListener('click', async () => {
+      const checked = document.querySelector('input[name="answer"]:checked');
+      if (!checked) return;
+      const res = await fetch(`/api/questions/${currentQuestion.id}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answer: checked.value })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = data.correct ? 'Correct! ' + data.explanation : 'Incorrect. ' + data.explanation;
+      await loadQuestion();
+    });
+
+    loadQuestion();
+  </script>
+</body>
+</html>

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ const express = require('express');
 function createApp(db) {
   const app = express();
   app.use(express.json());
+  app.use(express.static('public'));
 
   app.get('/api/questions', (req, res) => {
     db.all('SELECT * FROM questions', [], (err, rows) => {

--- a/tests/webapp.test.js
+++ b/tests/webapp.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const { initDB } = require('../server/db');
+const { createApp } = require('../server/app');
+
+let app;
+let db;
+
+beforeAll(async () => {
+  db = await initDB();
+  app = createApp(db);
+});
+
+afterAll(() => {
+  db.close();
+});
+
+test('GET / serves the web app', async () => {
+  const res = await request(app).get('/');
+  expect(res.status).toBe(200);
+  expect(res.type).toMatch(/html/);
+  expect(res.text).toContain('SC-200 Quiz');
+});


### PR DESCRIPTION
## Summary
- Serve static files via Express
- Add interactive quiz page fetching questions and posting answers
- Test that the root route serves HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c16c0e4524832c91a1b3aabafd743c