### PR TITLE
Add CSV deck import and refine flashcards key handling

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Backlog
 
-- Expand importer to handle CSV format and richer card fields (explanations, media).
 - Add Learn and Test modes with adaptive mastery tracking.
 - Enhance Flashcards with images/audio and progress persistence.
 - Improve accessibility and add text-to-speech playback.
 - Add unit/E2E tests for importer and study flows.
+- Importer UI for deck metadata (title/description) and file upload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 - Basic JSON deck importer with validation and localStorage persistence.
 - Flashcards study mode with keyboard navigation.
 - Utility `parseDeck` with unit tests.
+- `parseDeck` now supports CSV input and improved validation.
+- Flashcards key handler effect runs once to avoid redundant bindings.

--- a/src/importer/Importer.jsx
+++ b/src/importer/Importer.jsx
@@ -20,9 +20,9 @@ export default function Importer({ onImported }) {
 
   return (
     <div>
-      <h2>Import Deck (JSON)</h2>
+      <h2>Import Deck (JSON or CSV)</h2>
       <textarea
-        aria-label="Deck JSON"
+        aria-label="Deck JSON or CSV"
         value={text}
         onChange={(e) => setText(e.target.value)}
         rows={10}

--- a/src/modes/Flashcards.jsx
+++ b/src/modes/Flashcards.jsx
@@ -29,7 +29,7 @@ export default function Flashcards({ deck }) {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  });
+  }, []);
 
   return (
     <div style={{ textAlign: 'center' }}>

--- a/src/util/parseDeck.js
+++ b/src/util/parseDeck.js
@@ -1,36 +1,148 @@
 /**
- * Parse a deck JSON string. Throws an Error if malformed.
- * Expected shape:
+ * Parse a deck from either JSON or CSV text. Throws an Error if malformed.
+ * The returned shape is:
  * {
- *   "id": string,
- *   "title": string,
- *   "description": string?,
- *   "cards": [
- *     {"id": string, "question": string, "options": string[], "correct": number, "explanation"?: string}
+ *   id: string,
+ *   title: string,
+ *   description?: string,
+ *   cards: [
+ *     {
+ *       id: string,
+ *       question: string,
+ *       options: string[],
+ *       correct: number,
+ *       explanation?: string,
+ *       refs?: string,
+ *       image?: string,
+ *       audio?: string,
+ *     }
  *   ]
  * }
  */
-export function parseDeck(json) {
+export function parseDeck(input) {
+  const text = input.trim();
+  if (!text) throw new Error('Empty input');
+  if (text.startsWith('{') || text.startsWith('[')) {
+    return parseJSONDeck(text);
+  }
+  return parseCSVDeck(text);
+}
+
+function parseJSONDeck(json) {
   let data;
   try {
     data = JSON.parse(json);
-  } catch (err) {
+  } catch {
     throw new Error('Invalid JSON');
   }
   if (!data || typeof data !== 'object') throw new Error('Deck must be an object');
   if (!data.title || typeof data.title !== 'string') throw new Error('Deck title missing');
   if (!Array.isArray(data.cards)) throw new Error('Deck cards missing');
 
-  data.cards.forEach((card, idx) => {
-    if (!card || typeof card !== 'object') throw new Error(`Card ${idx} invalid`);
-    if (!card.id) throw new Error(`Card ${idx} missing id`);
-    if (typeof card.question !== 'string') throw new Error(`Card ${idx} missing question`);
-    if (!Array.isArray(card.options) || card.options.length === 0) {
-      throw new Error(`Card ${idx} options missing`);
-    }
-    if (typeof card.correct !== 'number' || card.correct < 0 || card.correct >= card.options.length) {
-      throw new Error(`Card ${idx} correct index invalid`);
-    }
-  });
+  data.cards.forEach((card, idx) => validateCard(card, idx));
   return data;
 }
+
+function parseCSVDeck(csv) {
+  const rows = csv
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length);
+  if (rows.length < 2) throw new Error('CSV must have a header and at least one row');
+
+  const headers = splitCSVLine(rows[0]);
+  const required = ['id', 'question', 'correct'];
+  required.forEach((h) => {
+    if (!headers.includes(h)) throw new Error(`Missing required column: ${h}`);
+  });
+
+  const optionCols = headers.filter((h) => /^option[A-H]$/i.test(h));
+
+  const cards = rows.slice(1).map((line, idx) => {
+    const values = splitCSVLine(line);
+    if (values.length !== headers.length) {
+      throw new Error(`Row ${idx + 1} has wrong number of columns`);
+    }
+    const row = {};
+    headers.forEach((h, i) => {
+      row[h] = values[i];
+    });
+
+    const options = optionCols.map((c) => row[c]).filter(Boolean);
+    const card = {
+      id: row.id,
+      question: row.question,
+      options,
+      correct: parseCorrect(row.correct, options.length, idx),
+    };
+
+    if (row.explanation) card.explanation = row.explanation;
+    if (row.refs) card.refs = row.refs;
+    if (row.image) card.image = row.image;
+    if (row.audio) card.audio = row.audio;
+
+    validateCard(card, idx);
+    return card;
+  });
+
+  return {
+    id: `deck-${Date.now()}`,
+    title: 'Imported Deck',
+    cards,
+  };
+}
+
+function splitCSVLine(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      result.push(current.trim().replace(/^"|"$/g, ''));
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current.trim().replace(/^"|"$/g, ''));
+  return result;
+}
+
+function parseCorrect(value, optionCount, rowIdx) {
+  let index;
+  if (/^[A-H]$/i.test(value)) {
+    index = value.toUpperCase().charCodeAt(0) - 65;
+  } else {
+    const num = Number(value);
+    if (!Number.isInteger(num)) {
+      throw new Error(`Row ${rowIdx + 1} invalid correct value`);
+    }
+    index = num;
+  }
+  if (index < 0 || index >= optionCount) {
+    throw new Error(`Row ${rowIdx + 1} correct index invalid`);
+  }
+  return index;
+}
+
+function validateCard(card, idx) {
+  if (!card || typeof card !== 'object') throw new Error(`Card ${idx} invalid`);
+  if (!card.id) throw new Error(`Card ${idx} missing id`);
+  if (typeof card.question !== 'string' || !card.question) {
+    throw new Error(`Card ${idx} missing question`);
+  }
+  if (!Array.isArray(card.options) || card.options.length === 0) {
+    throw new Error(`Card ${idx} options missing`);
+  }
+  if (
+    typeof card.correct !== 'number' ||
+    card.correct < 0 ||
+    card.correct >= card.options.length
+  ) {
+    throw new Error(`Card ${idx} correct index invalid`);
+  }
+}
+

--- a/tests/parseDeck.test.js
+++ b/tests/parseDeck.test.js
@@ -15,11 +15,23 @@ test('parses valid deck', () => {
 });
 
 test('throws on invalid json', () => {
-  expect(() => parseDeck('not json')).toThrow('Invalid JSON');
+  expect(() => parseDeck('{not json}')).toThrow('Invalid JSON');
 });
 
 test('throws on missing title', () => {
   const bad = { ...sample };
   delete bad.title;
   expect(() => parseDeck(JSON.stringify(bad))).toThrow('Deck title missing');
+});
+
+test('parses CSV deck', () => {
+  const csv = 'id,question,optionA,optionB,correct\n1,Two?,Yes,No,A';
+  const deck = parseDeck(csv);
+  expect(deck.cards[0].question).toBe('Two?');
+  expect(deck.cards[0].correct).toBe(0);
+});
+
+test('CSV missing column throws', () => {
+  const csv = 'id,optionA,correct\n1,Yes,A';
+  expect(() => parseDeck(csv)).toThrow('Missing required column: question');
 });

--- a/tests/placeholder.test.js
+++ b/tests/placeholder.test.js
@@ -1,3 +1,0 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
-});


### PR DESCRIPTION
## Summary
- support importing decks from CSV or JSON with stronger validation
- run flashcard keyboard handlers once to avoid duplicate bindings
- expand tests for parseDeck and clean up placeholder

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1715e2234832cb9232ebcdf4c0ab8