### PR TITLE
feat: add basic test mode

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,7 @@
 # Backlog
 
-- Add Learn and Test modes with adaptive mastery tracking.
+- Implement Learn mode with adaptive mastery tracking.
+- Enhance Test mode with question types, explanations review, and retesting wrong answers.
 - Enhance Flashcards with images/audio and progress persistence.
 - Improve accessibility and add text-to-speech playback.
 - Add unit/E2E tests for importer and study flows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Utility `parseDeck` with unit tests.
 - `parseDeck` now supports CSV input and improved validation.
 - Flashcards key handler effect runs once to avoid redundant bindings.
+- Basic multiple-choice Test mode with scoring.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import Importer from './importer/Importer.jsx';
 import Flashcards from './modes/Flashcards.jsx';
+import Test from './modes/Test.jsx';
 import { loadDecks } from './state/deckStore.js';
 
 export default function App() {
   const [deck, setDeck] = useState(null);
+  const [mode, setMode] = useState('flashcards');
 
   useEffect(() => {
     const decks = loadDecks();
@@ -15,7 +17,21 @@ export default function App() {
     <main>
       <h1>SC-200 Quiz</h1>
       {deck ? (
-        <Flashcards deck={deck} />
+        <div>
+          <nav>
+            <button onClick={() => setMode('flashcards')} aria-label="Flashcards mode">
+              Flashcards
+            </button>
+            <button onClick={() => setMode('test')} aria-label="Test mode">
+              Test
+            </button>
+          </nav>
+          {mode === 'flashcards' ? (
+            <Flashcards deck={deck} />
+          ) : (
+            <Test deck={deck} />
+          )}
+        </div>
       ) : (
         <Importer onImported={setDeck} />
       )}

--- a/src/modes/Test.jsx
+++ b/src/modes/Test.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { scoreTest } from '../util/scoreTest.js';
+
+export default function Test({ deck }) {
+  const [index, setIndex] = useState(0);
+  const [responses, setResponses] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [checked, setChecked] = useState(false);
+
+  const card = deck.cards[index];
+
+  if (index >= deck.cards.length) {
+    const summary = scoreTest(deck, responses);
+    return (
+      <div>
+        <h2>Results</h2>
+        <p>
+          Score: {summary.correct} / {summary.total}
+        </p>
+      </div>
+    );
+  }
+
+  const handleCheck = () => {
+    if (selected == null) return;
+    const nextResponses = [...responses];
+    nextResponses[index] = selected;
+    setResponses(nextResponses);
+    setChecked(true);
+  };
+
+  const handleNext = () => {
+    setSelected(null);
+    setChecked(false);
+    setIndex((i) => i + 1);
+  };
+
+  return (
+    <div>
+      <h2>{deck.title} - Question {index + 1}</h2>
+      <p>{card.question}</p>
+      <form>
+        {card.options.map((opt, i) => (
+          <div key={i}>
+            <label>
+              <input
+                type="radio"
+                name="option"
+                checked={selected === i}
+                onChange={() => setSelected(i)}
+                disabled={checked}
+              />
+              {opt}
+            </label>
+          </div>
+        ))}
+      </form>
+      {!checked ? (
+        <button onClick={handleCheck} disabled={selected == null}>
+          Check
+        </button>
+      ) : (
+        <div>
+          {selected === card.correct ? <p>Correct!</p> : <p>Incorrect.</p>}
+          {card.explanation && <p>{card.explanation}</p>}
+          <button onClick={handleNext}>Next</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/util/scoreTest.js
+++ b/src/util/scoreTest.js
@@ -1,0 +1,14 @@
+/**
+ * Compute quiz score.
+ * @param {{cards: {correct: number}[]}} deck
+ * @param {number[]} responses Index of chosen option per card.
+ * @returns {{correct: number, total: number, results: boolean[]}}
+ */
+export function scoreTest(deck, responses) {
+  const total = deck.cards.length;
+  const results = deck.cards.map((card, i) => {
+    return responses[i] === card.correct;
+  });
+  const correct = results.filter(Boolean).length;
+  return { correct, total, results };
+}

--- a/tests/scoreTest.test.js
+++ b/tests/scoreTest.test.js
@@ -1,0 +1,21 @@
+import { scoreTest } from '../src/util/scoreTest.js';
+
+describe('scoreTest', () => {
+  const deck = {
+    cards: [
+      { correct: 1 },
+      { correct: 0 },
+      { correct: 2 }
+    ]
+  };
+
+  it('scores correct answers', () => {
+    const res = scoreTest(deck, [1, 0, 2]);
+    expect(res).toEqual({ correct: 3, total: 3, results: [true, true, true] });
+  });
+
+  it('scores mixed answers', () => {
+    const res = scoreTest(deck, [0, 0, 1]);
+    expect(res).toEqual({ correct: 1, total: 3, results: [false, true, false] });
+  });
+});


### PR DESCRIPTION
## Summary
- add multiple-choice Test study mode with scoring
- introduce reusable `scoreTest` util with unit tests
- allow mode switching between Flashcards and Test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1728a83b4832cba25307db147844d