### PR TITLE
feat: add media support to flashcards

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,6 +2,6 @@
 
 - Implement Learn mode with adaptive mastery tracking.
 - Enhance Test mode with additional question types and richer explanations review.
-- Enhance Flashcards with images/audio and progress persistence.
+- Enhance Flashcards with progress persistence.
 - Improve accessibility and add text-to-speech playback.
 - Importer UI for deck metadata (title/description) and file upload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Flashcards key handler effect runs once to avoid redundant bindings.
 - Basic multiple-choice Test mode with scoring.
 - Test mode now shows per-question results and supports retaking incorrect answers.
+- Flashcards now display optional images, audio playback, and explanations.

--- a/src/modes/Flashcards.jsx
+++ b/src/modes/Flashcards.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 export default function Flashcards({ deck }) {
   const [index, setIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
+  const audioRef = useRef(null);
 
   const card = deck.cards[index];
 
@@ -17,6 +18,10 @@ export default function Flashcards({ deck }) {
   };
 
   const flip = () => setFlipped((f) => !f);
+  const playAudio = (e) => {
+    e.stopPropagation();
+    audioRef.current?.play();
+  };
 
   useEffect(() => {
     const handler = (e) => {
@@ -47,7 +52,28 @@ export default function Flashcards({ deck }) {
         aria-label="flashcard"
         onKeyDown={(e) => e.key === 'Enter' && flip()}
       >
-        {flipped ? card.options[card.correct] : card.question}
+        <p>{flipped ? card.options[card.correct] : card.question}</p>
+        {card.image && (
+          <img
+            src={card.image}
+            alt={card.question}
+            style={{ maxWidth: '100%', marginTop: '1rem' }}
+          />
+        )}
+        {card.audio && (
+          <div style={{ marginTop: '1rem' }}>
+            <audio ref={audioRef} src={card.audio} />
+            <button onClick={playAudio} aria-label="Play audio">
+              Play Audio
+            </button>
+          </div>
+        )}
+        {flipped && card.explanation && (
+          <p style={{ marginTop: '1rem' }}>{card.explanation}</p>
+        )}
+        {flipped && card.refs && (
+          <p style={{ marginTop: '0.5rem' }}>{card.refs}</p>
+        )}
       </div>
       <p>
         Card {index + 1} / {deck.cards.length}

--- a/tests/parseDeck.test.js
+++ b/tests/parseDeck.test.js
@@ -31,6 +31,30 @@ test('parses CSV deck', () => {
   expect(deck.cards[0].correct).toBe(0);
 });
 
+test('parses optional image/audio fields', () => {
+  const json = JSON.stringify({
+    ...sample,
+    cards: [
+      {
+        id: 'c1',
+        question: 'Q1',
+        options: ['A', 'B'],
+        correct: 0,
+        image: 'img.png',
+        audio: 'sound.mp3',
+      },
+    ],
+  });
+  const deck = parseDeck(json);
+  expect(deck.cards[0].image).toBe('img.png');
+  expect(deck.cards[0].audio).toBe('sound.mp3');
+
+  const csv = 'id,question,optionA,optionB,correct,image,audio\n1,Two?,Yes,No,A,pic.jpg,clip.mp3';
+  const csvDeck = parseDeck(csv);
+  expect(csvDeck.cards[0].image).toBe('pic.jpg');
+  expect(csvDeck.cards[0].audio).toBe('clip.mp3');
+});
+
 test('CSV missing column throws', () => {
   const csv = 'id,optionA,correct\n1,Yes,A';
   expect(() => parseDeck(csv)).toThrow('Missing required column: question');


### PR DESCRIPTION
## Summary
- show card images, audio playback, and explanations in Flashcards mode
- test parseDeck image/audio fields
- update backlog and changelog

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c175d8313c832c958e37ac4786c6fd