### PR TITLE
Add keyboard shortcuts for Test mode

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Backlog
 
 - Implement Learn mode with adaptive mastery tracking.
-- Enhance Test mode with additional question types and richer explanations review.
-- Enhance Flashcards with progress persistence.
-- Improve accessibility and add text-to-speech playback.
-- Importer UI for deck metadata (title/description) and file upload.
+- Expand Test mode with additional question types and richer explanations review.
+- Persist progress and add shuffle/randomization across modes.
+- Improve accessibility and integrated text-to-speech playback.
+- Add metadata fields and file upload to importer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Basic multiple-choice Test mode with scoring.
 - Test mode now shows per-question results and supports retaking incorrect answers.
 - Flashcards now display optional images, audio playback, and explanations.
+- Test mode gains keyboard shortcuts for option selection and navigation.

--- a/src/modes/Test.jsx
+++ b/src/modes/Test.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { scoreTest, getIncorrectCards } from '../util/scoreTest.js';
+import { keyToIndex } from '../util/keyToIndex.js';
 
 export default function Test({ deck }) {
   const [cards, setCards] = useState(deck.cards);
@@ -66,6 +67,28 @@ export default function Test({ deck }) {
     setChecked(false);
     setIndex((i) => i + 1);
   };
+
+  useEffect(() => {
+    const handler = (e) => {
+      const idx = keyToIndex(e.key);
+      if (!checked) {
+        if (idx >= 0 && idx < card.options.length) {
+          setSelected(idx);
+        }
+        if (e.key === 'Enter' && selected != null) {
+          e.preventDefault();
+          handleCheck();
+        }
+      } else {
+        if (e.key === 'Enter' || e.key === 'ArrowRight') {
+          e.preventDefault();
+          handleNext();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [checked, card.options.length, selected, handleCheck, handleNext]);
 
   return (
     <div>

--- a/src/util/keyToIndex.js
+++ b/src/util/keyToIndex.js
@@ -1,0 +1,20 @@
+/**
+ * Map keyboard key to an option index.
+ * Accepts numeric keys 1-8 and letter keys A-H (case-insensitive).
+ * Returns the zero-based index or -1 if not recognized.
+ * @param {string} key
+ * @returns {number}
+ */
+export function keyToIndex(key) {
+  if (!key) return -1;
+  // Numeric keys "1".."8"
+  if (/^[1-8]$/.test(key)) {
+    return Number(key) - 1;
+  }
+  // Letter keys "A".."H"
+  const upper = key.toUpperCase();
+  if (/^[A-H]$/.test(upper)) {
+    return upper.charCodeAt(0) - 65;
+  }
+  return -1;
+}

--- a/tests/keyToIndex.test.js
+++ b/tests/keyToIndex.test.js
@@ -1,0 +1,19 @@
+import { keyToIndex } from '../src/util/keyToIndex.js';
+
+describe('keyToIndex', () => {
+  test('maps numbers to indices', () => {
+    expect(keyToIndex('1')).toBe(0);
+    expect(keyToIndex('3')).toBe(2);
+  });
+
+  test('maps letters to indices case-insensitively', () => {
+    expect(keyToIndex('A')).toBe(0);
+    expect(keyToIndex('d')).toBe(3);
+  });
+
+  test('returns -1 for unknown keys', () => {
+    expect(keyToIndex('0')).toBe(-1);
+    expect(keyToIndex('Z')).toBe(-1);
+    expect(keyToIndex('')).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary
- add keyToIndex utility for mapping keyboard keys to answer indices
- enable keyboard navigation in Test mode (letters/numbers, Enter, ArrowRight)
- cover keyToIndex with unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c17743c678832c82f08bb1e2a5c340