### PR TITLE
feat(test): show media and refs in test mode

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Backlog
 
 - Implement Learn mode with adaptive mastery tracking.
-- Expand Test mode with additional question types and richer explanations review.
+- Expand Test mode with True/False and written question types plus enhanced review UI.
 - Persist progress and add shuffle/randomization across modes.
 - Improve accessibility and integrated text-to-speech playback.
 - Add metadata fields and file upload to importer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@
 - Test mode now shows per-question results and supports retaking incorrect answers.
 - Flashcards now display optional images, audio playback, and explanations.
 - Test mode gains keyboard shortcuts for option selection and navigation.
+- Test mode now displays optional images, audio playback, explanations, and references.
+- Importer tests cover explanation and reference fields.
+

--- a/src/modes/Test.jsx
+++ b/src/modes/Test.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { scoreTest, getIncorrectCards } from '../util/scoreTest.js';
 import { keyToIndex } from '../util/keyToIndex.js';
 
@@ -8,6 +8,8 @@ export default function Test({ deck }) {
   const [responses, setResponses] = useState([]);
   const [selected, setSelected] = useState(null);
   const [checked, setChecked] = useState(false);
+
+  const audioRef = useRef(null);
 
   const card = cards[index];
 
@@ -41,7 +43,22 @@ export default function Test({ deck }) {
                   Incorrect. Correct: {c.options[c.correct]}
                 </p>
               )}
+              {c.image && (
+                <img
+                  src={c.image}
+                  alt={c.question}
+                  style={{ maxWidth: '100%', marginTop: '0.5rem' }}
+                />
+              )}
+              {c.audio && (
+                <audio
+                  controls
+                  src={c.audio}
+                  style={{ display: 'block', marginTop: '0.5rem' }}
+                />
+              )}
               {c.explanation && <p>{c.explanation}</p>}
+              {c.refs && <p>{c.refs}</p>}
             </li>
           ))}
         </ul>
@@ -66,6 +83,11 @@ export default function Test({ deck }) {
     setSelected(null);
     setChecked(false);
     setIndex((i) => i + 1);
+  };
+
+  const playAudio = (e) => {
+    e.stopPropagation();
+    audioRef.current?.play();
   };
 
   useEffect(() => {
@@ -94,6 +116,21 @@ export default function Test({ deck }) {
     <div>
       <h2>{deck.title} - Question {index + 1}</h2>
       <p>{card.question}</p>
+      {card.image && (
+        <img
+          src={card.image}
+          alt={card.question}
+          style={{ maxWidth: '100%', marginTop: '1rem' }}
+        />
+      )}
+      {card.audio && (
+        <div style={{ marginTop: '1rem' }}>
+          <audio ref={audioRef} src={card.audio} />
+          <button onClick={playAudio} aria-label="Play audio">
+            Play Audio
+          </button>
+        </div>
+      )}
       <form>
         {card.options.map((opt, i) => (
           <div key={i}>
@@ -118,6 +155,7 @@ export default function Test({ deck }) {
         <div>
           {selected === card.correct ? <p>Correct!</p> : <p>Incorrect.</p>}
           {card.explanation && <p>{card.explanation}</p>}
+          {card.refs && <p>{card.refs}</p>}
           <button onClick={handleNext}>Next</button>
         </div>
       )}

--- a/tests/parseDeck.test.js
+++ b/tests/parseDeck.test.js
@@ -55,6 +55,30 @@ test('parses optional image/audio fields', () => {
   expect(csvDeck.cards[0].audio).toBe('clip.mp3');
 });
 
+test('parses optional explanation and refs fields', () => {
+  const json = JSON.stringify({
+    ...sample,
+    cards: [
+      {
+        id: 'c1',
+        question: 'Q1',
+        options: ['A', 'B'],
+        correct: 0,
+        explanation: 'because',
+        refs: 'ref-link',
+      },
+    ],
+  });
+  const deck = parseDeck(json);
+  expect(deck.cards[0].explanation).toBe('because');
+  expect(deck.cards[0].refs).toBe('ref-link');
+
+  const csv = 'id,question,optionA,optionB,correct,explanation,refs\n1,Two?,Yes,No,A,why,ref';
+  const csvDeck = parseDeck(csv);
+  expect(csvDeck.cards[0].explanation).toBe('why');
+  expect(csvDeck.cards[0].refs).toBe('ref');
+});
+
 test('CSV missing column throws', () => {
   const csv = 'id,optionA,correct\n1,Yes,A';
   expect(() => parseDeck(csv)).toThrow('Missing required column: question');


### PR DESCRIPTION
## Summary
- show optional images, audio, explanations, and references during Test mode questions and results
- add unit tests verifying parseDeck reads explanation and reference fields

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1786135bc832c885243effa68b241