### PR TITLE
Add flashcard shuffle and stabilize test handler

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Backlog
 
 - Implement Learn mode with adaptive mastery tracking.
+- Add Match mode with timed pairing and personal best tracking.
 - Expand Test mode with True/False and written question types plus enhanced review UI.
-- Persist progress and add shuffle/randomization across modes.
-- Improve accessibility and integrated text-to-speech playback.
-- Add metadata fields and file upload to importer.
+- Support file upload and metadata in importer.
+- Persist progress and unify shuffle/randomization across all modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@
 - Test mode gains keyboard shortcuts for option selection and navigation.
 - Test mode now displays optional images, audio playback, explanations, and references.
 - Importer tests cover explanation and reference fields.
+- Test mode keyboard handler stabilized with useCallback to avoid re-binding listeners.
+- Flashcards mode adds shuffle button and progress bar for better study tracking.
 

--- a/src/modes/Flashcards.jsx
+++ b/src/modes/Flashcards.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { shuffleArray } from '../util/shuffle.js';
 
 export default function Flashcards({ deck }) {
+  const [order, setOrder] = useState(() => deck.cards.map((_, i) => i));
   const [index, setIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const audioRef = useRef(null);
 
-  const card = deck.cards[index];
+  const card = deck.cards[order[index]];
 
   const next = () => {
     setIndex((i) => (i + 1) % deck.cards.length);
@@ -14,6 +16,12 @@ export default function Flashcards({ deck }) {
 
   const prev = () => {
     setIndex((i) => (i - 1 + deck.cards.length) % deck.cards.length);
+    setFlipped(false);
+  };
+
+  const shuffle = () => {
+    setOrder((o) => shuffleArray(o));
+    setIndex(0);
     setFlipped(false);
   };
 
@@ -78,6 +86,12 @@ export default function Flashcards({ deck }) {
       <p>
         Card {index + 1} / {deck.cards.length}
       </p>
+      <progress value={index + 1} max={deck.cards.length} aria-label="Progress" />
+      <div style={{ marginTop: '0.5rem' }}>
+        <button onClick={shuffle} aria-label="Shuffle cards" style={{ marginRight: '0.5rem' }}>
+          Shuffle
+        </button>
+      </div>
       <button onClick={prev} aria-label="Previous card">
         Prev
       </button>

--- a/src/modes/Test.jsx
+++ b/src/modes/Test.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { scoreTest, getIncorrectCards } from '../util/scoreTest.js';
 import { keyToIndex } from '../util/keyToIndex.js';
 
@@ -71,19 +71,19 @@ export default function Test({ deck }) {
     );
   }
 
-  const handleCheck = () => {
+  const handleCheck = useCallback(() => {
     if (selected == null) return;
     const nextResponses = [...responses];
     nextResponses[index] = selected;
     setResponses(nextResponses);
     setChecked(true);
-  };
+  }, [index, responses, selected]);
 
-  const handleNext = () => {
+  const handleNext = useCallback(() => {
     setSelected(null);
     setChecked(false);
     setIndex((i) => i + 1);
-  };
+  }, []);
 
   const playAudio = (e) => {
     e.stopPropagation();

--- a/src/util/shuffle.js
+++ b/src/util/shuffle.js
@@ -1,0 +1,14 @@
+/**
+ * Return a new array with elements shuffled using Fisher-Yates.
+ * @template T
+ * @param {T[]} arr
+ * @returns {T[]}
+ */
+export function shuffleArray(arr) {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}

--- a/tests/shuffle.test.js
+++ b/tests/shuffle.test.js
@@ -1,0 +1,15 @@
+import { shuffleArray } from '../src/util/shuffle.js';
+
+describe('shuffleArray', () => {
+  test('returns new array with same elements', () => {
+    const original = [1, 2, 3, 4];
+    const result = shuffleArray(original);
+    expect(result).toHaveLength(original.length);
+    // Same elements regardless of order
+    expect(result.sort()).toEqual([...original].sort());
+    // Ensure original not mutated
+    expect(original).toEqual([1, 2, 3, 4]);
+    // Result should be different reference
+    expect(result).not.toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary
- add shuffle util and button with progress bar in flashcards mode
- stabilize Test mode keyboard handlers using useCallback
- include shuffle util tests

## Testing
- `npm test --silent`
- `npm run build --silent` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c17a1bda90832c865b71d72758ed43