### PR TITLE
feat: add learn mode and improve importer

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Backlog
 
-- Implement Learn mode with adaptive mastery tracking.
 - Add Match mode with timed pairing and personal best tracking.
 - Expand Test mode with True/False and written question types plus enhanced review UI.
 - Support file upload and metadata in importer.
 - Persist progress and unify shuffle/randomization across all modes.
+- Improve styling and dark mode support across components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,7 @@
 - Importer tests cover explanation and reference fields.
 - Test mode keyboard handler stabilized with useCallback to avoid re-binding listeners.
 - Flashcards mode adds shuffle button and progress bar for better study tracking.
+- JSON importer assigns an ID when missing to ensure decks are storable.
+- Added adaptive Learn mode with keyboard support and mastery progress.
+- Learn queue utility with unit tests.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Importer from './importer/Importer.jsx';
 import Flashcards from './modes/Flashcards.jsx';
 import Test from './modes/Test.jsx';
+import Learn from './modes/Learn.jsx';
 import { loadDecks } from './state/deckStore.js';
 
 export default function App() {
@@ -22,15 +23,16 @@ export default function App() {
             <button onClick={() => setMode('flashcards')} aria-label="Flashcards mode">
               Flashcards
             </button>
+            <button onClick={() => setMode('learn')} aria-label="Learn mode">
+              Learn
+            </button>
             <button onClick={() => setMode('test')} aria-label="Test mode">
               Test
             </button>
           </nav>
-          {mode === 'flashcards' ? (
-            <Flashcards deck={deck} />
-          ) : (
-            <Test deck={deck} />
-          )}
+          {mode === 'flashcards' && <Flashcards deck={deck} />}
+          {mode === 'learn' && <Learn deck={deck} />}
+          {mode === 'test' && <Test deck={deck} />}
         </div>
       ) : (
         <Importer onImported={setDeck} />

--- a/src/modes/Learn.jsx
+++ b/src/modes/Learn.jsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { keyToIndex } from '../util/keyToIndex.js';
+import { advanceLearnQueue } from '../util/learnQueue.js';
+
+export default function Learn({ deck }) {
+  const [queue, setQueue] = useState(deck.cards);
+  const [selected, setSelected] = useState(null);
+  const [result, setResult] = useState(null); // null or boolean
+  const audioRef = useRef(null);
+  const current = queue[0];
+
+  const playAudio = (e) => {
+    e.stopPropagation();
+    audioRef.current?.play();
+  };
+
+  const handleCheck = useCallback(() => {
+    if (selected == null) return;
+    setResult(selected === current.correct);
+  }, [selected, current]);
+
+  const handleNext = useCallback(() => {
+    setQueue((q) => advanceLearnQueue(q, result));
+    setSelected(null);
+    setResult(null);
+  }, [result]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const idx = keyToIndex(e.key);
+      if (result == null) {
+        if (idx >= 0 && idx < current.options.length) {
+          setSelected(idx);
+        }
+        if (e.key === 'Enter' && selected != null) {
+          e.preventDefault();
+          handleCheck();
+        }
+      } else {
+        if (e.key === 'Enter' || e.key === 'ArrowRight') {
+          e.preventDefault();
+          handleNext();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [result, current, selected, handleCheck, handleNext]);
+
+  if (!current) {
+    return (
+      <div>
+        <h2>{deck.title} - Mastered!</h2>
+        <p>All cards mastered.</p>
+      </div>
+    );
+  }
+
+  const mastered = deck.cards.length - queue.length;
+  return (
+    <div>
+      <h2>
+        {deck.title} - Learn ({mastered}/{deck.cards.length})
+      </h2>
+      <p>{current.question}</p>
+      {current.image && (
+        <img
+          src={current.image}
+          alt={current.question}
+          style={{ maxWidth: '100%', marginTop: '1rem' }}
+        />
+      )}
+      {current.audio && (
+        <div style={{ marginTop: '1rem' }}>
+          <audio ref={audioRef} src={current.audio} />
+          <button onClick={playAudio} aria-label="Play audio">
+            Play Audio
+          </button>
+        </div>
+      )}
+      <form>
+        {current.options.map((opt, i) => (
+          <div key={i}>
+            <label>
+              <input
+                type="radio"
+                name="option"
+                checked={selected === i}
+                onChange={() => setSelected(i)}
+                disabled={result != null}
+              />
+              {opt}
+            </label>
+          </div>
+        ))}
+      </form>
+      {result == null ? (
+        <button onClick={handleCheck} disabled={selected == null}>
+          Check
+        </button>
+      ) : (
+        <div>
+          {result ? <p>Correct!</p> : <p>Incorrect.</p>}
+          {current.explanation && <p>{current.explanation}</p>}
+          {current.refs && <p>{current.refs}</p>}
+          <button onClick={handleNext}>Next</button>
+        </div>
+      )}
+      <progress
+        value={mastered}
+        max={deck.cards.length}
+        aria-label="Mastery progress"
+      />
+    </div>
+  );
+}

--- a/src/util/learnQueue.js
+++ b/src/util/learnQueue.js
@@ -1,0 +1,7 @@
+export function advanceLearnQueue(queue, wasCorrect) {
+  const [first, ...rest] = queue;
+  if (wasCorrect) {
+    return rest;
+  }
+  return [...rest, first];
+}

--- a/src/util/parseDeck.js
+++ b/src/util/parseDeck.js
@@ -39,6 +39,10 @@ function parseJSONDeck(json) {
   if (!data.title || typeof data.title !== 'string') throw new Error('Deck title missing');
   if (!Array.isArray(data.cards)) throw new Error('Deck cards missing');
 
+  if (!data.id) {
+    data.id = `deck-${Date.now()}`;
+  }
+
   data.cards.forEach((card, idx) => validateCard(card, idx));
   return data;
 }

--- a/tests/learnQueue.test.js
+++ b/tests/learnQueue.test.js
@@ -1,0 +1,13 @@
+import { advanceLearnQueue } from '../src/util/learnQueue.js';
+
+test('removes card when answered correctly', () => {
+  const queue = [1,2,3];
+  const next = advanceLearnQueue(queue, true);
+  expect(next).toEqual([2,3]);
+});
+
+test('requeues card when answered incorrectly', () => {
+  const queue = [1,2,3];
+  const next = advanceLearnQueue(queue, false);
+  expect(next).toEqual([2,3,1]);
+});

--- a/tests/parseDeck.test.js
+++ b/tests/parseDeck.test.js
@@ -24,6 +24,12 @@ test('throws on missing title', () => {
   expect(() => parseDeck(JSON.stringify(bad))).toThrow('Deck title missing');
 });
 
+test('adds id when missing in JSON deck', () => {
+  const json = JSON.stringify({ title: 'Sample', cards: sample.cards });
+  const deck = parseDeck(json);
+  expect(deck.id).toBeTruthy();
+});
+
 test('parses CSV deck', () => {
   const csv = 'id,question,optionA,optionB,correct\n1,Two?,Yes,No,A';
   const deck = parseDeck(csv);


### PR DESCRIPTION
## Summary
- generate unique ID for JSON-imported decks
- add adaptive Learn mode with keyboard support and mastery progress
- factor learn queue utility with tests

## Testing
- `npm test`
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68c17b3ea470832c8e326ba05b1af94a