### PR TITLE
Modernize UI with dark theme and animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "csv-parser": "^3.0.0",
+        "lucide-react": "^0.344.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -3617,6 +3618,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.344.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
+      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "csv-parser": "^3.0.0",
+    "lucide-react": "^0.344.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,43 @@
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+}
+
+h1 {
+  text-align: center;
+  font-weight: 700;
+  margin-bottom: 2rem;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.navbar nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.navbar button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(255,255,255,0.05);
+}
+
+.navbar button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.theme-toggle {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,11 +3,20 @@ import Importer from './importer/Importer.jsx';
 import Flashcards from './modes/Flashcards.jsx';
 import Test from './modes/Test.jsx';
 import Learn from './modes/Learn.jsx';
+import Navbar from './ui/Navbar.jsx';
 import { loadDecks } from './state/deckStore.js';
+import './App.css';
 
 export default function App() {
   const [deck, setDeck] = useState(null);
   const [mode, setMode] = useState('flashcards');
+  const [theme, setTheme] = useState('dark');
+
+  useEffect(() => {
+    document.body.className = theme;
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
 
   useEffect(() => {
     const decks = loadDecks();
@@ -18,22 +27,17 @@ export default function App() {
     <main>
       <h1>SC-200 Quiz</h1>
       {deck ? (
-        <div>
-          <nav>
-            <button onClick={() => setMode('flashcards')} aria-label="Flashcards mode">
-              Flashcards
-            </button>
-            <button onClick={() => setMode('learn')} aria-label="Learn mode">
-              Learn
-            </button>
-            <button onClick={() => setMode('test')} aria-label="Test mode">
-              Test
-            </button>
-          </nav>
+        <>
+          <Navbar
+            mode={mode}
+            setMode={setMode}
+            theme={theme}
+            toggleTheme={toggleTheme}
+          />
           {mode === 'flashcards' && <Flashcards deck={deck} />}
           {mode === 'learn' && <Learn deck={deck} />}
           {mode === 'test' && <Test deck={deck} />}
-        </div>
+        </>
       ) : (
         <Importer onImported={setDeck} />
       )}

--- a/src/importer/Importer.css
+++ b/src/importer/Importer.css
@@ -1,0 +1,24 @@
+.importer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.importer textarea {
+  width: 100%;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
+  color: inherit;
+  padding: 1rem;
+}
+
+.importer button {
+  align-self: flex-start;
+  background: var(--accent);
+  color: #fff;
+}
+
+.importer p.error {
+  color: #ef4444;
+}

--- a/src/importer/Importer.jsx
+++ b/src/importer/Importer.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { parseDeck } from '../util/parseDeck.js';
 import { saveDeck } from '../state/deckStore.js';
+import './Importer.css';
 
 export default function Importer({ onImported }) {
   const [text, setText] = useState('');
@@ -19,16 +20,15 @@ export default function Importer({ onImported }) {
   };
 
   return (
-    <div>
+    <div className="importer">
       <h2>Import Deck (JSON or CSV)</h2>
       <textarea
         aria-label="Deck JSON or CSV"
         value={text}
         onChange={(e) => setText(e.target.value)}
         rows={10}
-        style={{ width: '100%' }}
       />
-      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {error && <p className="error">{error}</p>}
       <button onClick={handleImport}>Import</button>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,56 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+:root {
+  --bg-dark: #0f172a;
+  --bg-light: #f8fafc;
+  --text-dark: #f1f5f9;
+  --text-light: #0f172a;
+  --accent: linear-gradient(135deg,#06b6d4 0%,#3b82f6 100%);
+  --radius: 12px;
+  --transition: 0.3s ease;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: var(--bg-dark);
+  color: var(--text-dark);
+  -webkit-font-smoothing: antialiased;
+}
+
+body.light {
+  background: var(--bg-light);
+  color: var(--text-light);
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.5rem 1rem;
+  background: transparent;
+  color: inherit;
+  transition: background var(--transition), color var(--transition);
+}
+
+button:hover:not(:disabled) {
+  background: rgba(255,255,255,0.1);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.card {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  backdrop-filter: blur(10px);
+}
+
+input, textarea {
+  font-family: inherit;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import './index.css';
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/src/modes/Flashcards.css
+++ b/src/modes/Flashcards.css
@@ -1,0 +1,59 @@
+.flashcard-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.flashcard {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  height: 300px;
+  perspective: 1000px;
+}
+
+.flashcard-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+  cursor: pointer;
+}
+
+.flashcard.flipped .flashcard-inner {
+  transform: rotateY(180deg);
+}
+
+.flashcard-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+}
+
+.flashcard-face.back {
+  transform: rotateY(180deg);
+}
+
+.progress {
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius);
+}
+
+.progress::-webkit-progress-bar {
+  background: rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+}
+
+.progress::-webkit-progress-value {
+  background: var(--accent);
+  border-radius: var(--radius);
+}

--- a/src/modes/Flashcards.jsx
+++ b/src/modes/Flashcards.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { shuffleArray } from '../util/shuffle.js';
+import './Flashcards.css';
 
 export default function Flashcards({ deck }) {
   const [order, setOrder] = useState(() => deck.cards.map((_, i) => i));
@@ -45,62 +46,53 @@ export default function Flashcards({ deck }) {
   }, []);
 
   return (
-    <div style={{ textAlign: 'center' }}>
+    <div className="flashcard-container">
       <h2>{deck.title}</h2>
       <div
-        style={{
-          border: '1px solid #ccc',
-          padding: '2rem',
-          cursor: 'pointer',
-          minHeight: '200px',
-        }}
+        className={`flashcard card ${flipped ? 'flipped' : ''}`}
         onClick={flip}
         role="button"
         tabIndex={0}
         aria-label="flashcard"
         onKeyDown={(e) => e.key === 'Enter' && flip()}
       >
-        <p>{flipped ? card.options[card.correct] : card.question}</p>
-        {card.image && (
-          <img
-            src={card.image}
-            alt={card.question}
-            style={{ maxWidth: '100%', marginTop: '1rem' }}
-          />
-        )}
-        {card.audio && (
-          <div style={{ marginTop: '1rem' }}>
-            <audio ref={audioRef} src={card.audio} />
-            <button onClick={playAudio} aria-label="Play audio">
-              Play Audio
-            </button>
+        <div className="flashcard-inner">
+          <div className="flashcard-face front">
+            <p>{card.question}</p>
+            {card.image && <img src={card.image} alt={card.question} />}
           </div>
-        )}
-        {flipped && card.explanation && (
-          <p style={{ marginTop: '1rem' }}>{card.explanation}</p>
-        )}
-        {flipped && card.refs && (
-          <p style={{ marginTop: '0.5rem' }}>{card.refs}</p>
-        )}
+          <div className="flashcard-face back">
+            <p>{card.options[card.correct]}</p>
+            {card.explanation && <p style={{ marginTop: '1rem' }}>{card.explanation}</p>}
+            {card.refs && <p style={{ marginTop: '0.5rem' }}>{card.refs}</p>}
+          </div>
+        </div>
       </div>
+      {card.audio && (
+        <div>
+          <audio ref={audioRef} src={card.audio} />
+          <button onClick={playAudio} aria-label="Play audio">Play Audio</button>
+        </div>
+      )}
       <p>
         Card {index + 1} / {deck.cards.length}
       </p>
-      <progress value={index + 1} max={deck.cards.length} aria-label="Progress" />
-      <div style={{ marginTop: '0.5rem' }}>
-        <button onClick={shuffle} aria-label="Shuffle cards" style={{ marginRight: '0.5rem' }}>
+      <progress
+        className="progress"
+        value={index + 1}
+        max={deck.cards.length}
+        aria-label="Progress"
+      />
+      <div>
+        <button onClick={shuffle} aria-label="Shuffle cards">
           Shuffle
         </button>
       </div>
-      <button onClick={prev} aria-label="Previous card">
-        Prev
-      </button>
-      <button onClick={flip} aria-label="Flip card">
-        Flip
-      </button>
-      <button onClick={next} aria-label="Next card">
-        Next
-      </button>
+      <div>
+        <button onClick={prev} aria-label="Previous card">Prev</button>
+        <button onClick={flip} aria-label="Flip card">Flip</button>
+        <button onClick={next} aria-label="Next card">Next</button>
+      </div>
     </div>
   );
 }

--- a/src/modes/Learn.css
+++ b/src/modes/Learn.css
@@ -1,0 +1,57 @@
+.learn-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.options {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.option {
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition), border var(--transition);
+}
+
+.option:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+.option.selected {
+  border-color: var(--accent);
+}
+
+.option.correct {
+  background: rgba(34,197,94,0.2);
+  border-color: #22c55e;
+}
+
+.option.incorrect {
+  background: rgba(239,68,68,0.2);
+  border-color: #ef4444;
+}
+
+.feedback {
+  font-weight: 600;
+}
+
+.progress {
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius);
+}
+
+.progress::-webkit-progress-bar {
+  background: rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+}
+
+.progress::-webkit-progress-value {
+  background: var(--accent);
+  border-radius: var(--radius);
+}

--- a/src/modes/Learn.jsx
+++ b/src/modes/Learn.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { keyToIndex } from '../util/keyToIndex.js';
 import { advanceLearnQueue } from '../util/learnQueue.js';
+import './Learn.css';
 
 export default function Learn({ deck }) {
   const [queue, setQueue] = useState(deck.cards);
@@ -49,7 +50,7 @@ export default function Learn({ deck }) {
 
   if (!current) {
     return (
-      <div>
+      <div className="learn-container">
         <h2>{deck.title} - Mastered!</h2>
         <p>All cards mastered.</p>
       </div>
@@ -58,7 +59,7 @@ export default function Learn({ deck }) {
 
   const mastered = deck.cards.length - queue.length;
   return (
-    <div>
+    <div className="learn-container">
       <h2>
         {deck.title} - Learn ({mastered}/{deck.cards.length})
       </h2>
@@ -71,42 +72,43 @@ export default function Learn({ deck }) {
         />
       )}
       {current.audio && (
-        <div style={{ marginTop: '1rem' }}>
+        <div>
           <audio ref={audioRef} src={current.audio} />
-          <button onClick={playAudio} aria-label="Play audio">
-            Play Audio
-          </button>
+          <button onClick={playAudio} aria-label="Play audio">Play Audio</button>
         </div>
       )}
-      <form>
+      <form className="options">
         {current.options.map((opt, i) => (
-          <div key={i}>
-            <label>
-              <input
-                type="radio"
-                name="option"
-                checked={selected === i}
-                onChange={() => setSelected(i)}
-                disabled={result != null}
-              />
-              {opt}
-            </label>
-          </div>
+          <label
+            key={i}
+            className={`option ${selected === i ? 'selected' : ''} ${
+              result != null ? (i === current.correct ? 'correct' : selected === i ? 'incorrect' : '') : ''
+            }`}
+          >
+            <input
+              type="radio"
+              name="option"
+              checked={selected === i}
+              onChange={() => setSelected(i)}
+              disabled={result != null}
+              style={{ display: 'none' }}
+            />
+            {opt}
+          </label>
         ))}
       </form>
       {result == null ? (
-        <button onClick={handleCheck} disabled={selected == null}>
-          Check
-        </button>
+        <button onClick={handleCheck} disabled={selected == null}>Check</button>
       ) : (
         <div>
-          {result ? <p>Correct!</p> : <p>Incorrect.</p>}
+          <p className="feedback">{result ? 'Correct!' : 'Incorrect.'}</p>
           {current.explanation && <p>{current.explanation}</p>}
           {current.refs && <p>{current.refs}</p>}
           <button onClick={handleNext}>Next</button>
         </div>
       )}
       <progress
+        className="progress"
         value={mastered}
         max={deck.cards.length}
         aria-label="Mastery progress"

--- a/src/modes/Test.css
+++ b/src/modes/Test.css
@@ -1,0 +1,53 @@
+.test-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.options {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.option {
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition), border var(--transition);
+}
+
+.option:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+.option.selected {
+  border-color: var(--accent);
+}
+
+.option.correct {
+  background: rgba(34,197,94,0.2);
+  border-color: #22c55e;
+}
+
+.option.incorrect {
+  background: rgba(239,68,68,0.2);
+  border-color: #ef4444;
+}
+
+.progress {
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius);
+}
+
+.progress::-webkit-progress-bar {
+  background: rgba(255,255,255,0.1);
+  border-radius: var(--radius);
+}
+
+.progress::-webkit-progress-value {
+  background: var(--accent);
+  border-radius: var(--radius);
+}

--- a/src/modes/Test.jsx
+++ b/src/modes/Test.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { scoreTest, getIncorrectCards } from '../util/scoreTest.js';
 import { keyToIndex } from '../util/keyToIndex.js';
+import './Test.css';
 
 export default function Test({ deck }) {
   const [cards, setCards] = useState(deck.cards);
@@ -27,7 +28,7 @@ export default function Test({ deck }) {
     };
 
     return (
-      <div>
+      <div className="test-container">
         <h2>Results</h2>
         <p>
           Score: {summary.correct} / {summary.total}
@@ -113,7 +114,7 @@ export default function Test({ deck }) {
   }, [checked, card.options.length, selected, handleCheck, handleNext]);
 
   return (
-    <div>
+    <div className="test-container">
       <h2>{deck.title} - Question {index + 1}</h2>
       <p>{card.question}</p>
       {card.image && (
@@ -124,41 +125,47 @@ export default function Test({ deck }) {
         />
       )}
       {card.audio && (
-        <div style={{ marginTop: '1rem' }}>
+        <div>
           <audio ref={audioRef} src={card.audio} />
-          <button onClick={playAudio} aria-label="Play audio">
-            Play Audio
-          </button>
+          <button onClick={playAudio} aria-label="Play audio">Play Audio</button>
         </div>
       )}
-      <form>
+      <form className="options">
         {card.options.map((opt, i) => (
-          <div key={i}>
-            <label>
-              <input
-                type="radio"
-                name="option"
-                checked={selected === i}
-                onChange={() => setSelected(i)}
-                disabled={checked}
-              />
-              {opt}
-            </label>
-          </div>
+          <label
+            key={i}
+            className={`option ${selected === i ? 'selected' : ''} ${
+              checked ? (i === card.correct ? 'correct' : selected === i ? 'incorrect' : '') : ''
+            }`}
+          >
+            <input
+              type="radio"
+              name="option"
+              checked={selected === i}
+              onChange={() => setSelected(i)}
+              disabled={checked}
+              style={{ display: 'none' }}
+            />
+            {opt}
+          </label>
         ))}
       </form>
       {!checked ? (
-        <button onClick={handleCheck} disabled={selected == null}>
-          Check
-        </button>
+        <button onClick={handleCheck} disabled={selected == null}>Check</button>
       ) : (
         <div>
-          {selected === card.correct ? <p>Correct!</p> : <p>Incorrect.</p>}
+          <p className="feedback">{selected === card.correct ? 'Correct!' : 'Incorrect.'}</p>
           {card.explanation && <p>{card.explanation}</p>}
           {card.refs && <p>{card.refs}</p>}
           <button onClick={handleNext}>Next</button>
         </div>
       )}
+      <progress
+        className="progress"
+        value={index + 1}
+        max={cards.length}
+        aria-label="Test progress"
+      />
     </div>
   );
 }

--- a/src/ui/Navbar.jsx
+++ b/src/ui/Navbar.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FlipHorizontal2, BookOpen, CheckCircle2, Sun, Moon } from 'lucide-react';
+
+export default function Navbar({ mode, setMode, theme, toggleTheme }) {
+  const items = [
+    { id: 'flashcards', label: 'Flashcards', icon: <FlipHorizontal2 size={18} /> },
+    { id: 'learn', label: 'Learn', icon: <BookOpen size={18} /> },
+    { id: 'test', label: 'Test', icon: <CheckCircle2 size={18} /> },
+  ];
+
+  return (
+    <header className="navbar">
+      <nav>
+        {items.map((item) => (
+          <button
+            key={item.id}
+            className={mode === item.id ? 'active' : ''}
+            onClick={() => setMode(item.id)}
+            aria-label={`${item.label} mode`}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </nav>
+      <button className="theme-toggle" onClick={toggleTheme} aria-label="Toggle theme">
+        {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
+      </button>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- Adopt Inter-based dark theme and glassy card styles.
- Add icon navbar with theme toggle and polish Flashcards, Learn, Test, and Importer UIs.
- Integrate animated flashcard flipping and styled answer feedback.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17cad2d28832ca19a66681f996bfb