### PR TITLE
feat: add file importer and landing dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,12 +4,14 @@ import Flashcards from './modes/Flashcards.jsx';
 import Test from './modes/Test.jsx';
 import Learn from './modes/Learn.jsx';
 import Navbar from './ui/Navbar.jsx';
+import Landing from './ui/Landing.jsx';
+import Dashboard from './ui/Dashboard.jsx';
 import { loadDecks } from './state/deckStore.js';
 import './App.css';
 
 export default function App() {
   const [deck, setDeck] = useState(null);
-  const [mode, setMode] = useState('flashcards');
+  const [view, setView] = useState('landing');
   const [theme, setTheme] = useState('dark');
 
   useEffect(() => {
@@ -26,20 +28,44 @@ export default function App() {
   return (
     <main>
       <h1>SC-200 Quiz</h1>
-      {deck ? (
+      {view === 'landing' && (
+        <Landing
+          onImport={() => setView('import')}
+          hasDeck={!!deck}
+          onStart={() => setView('dashboard')}
+        />
+      )}
+      {view === 'import' && (
+        <Importer
+          onImported={(d) => {
+            setDeck(d);
+            setView('dashboard');
+          }}
+        />
+      )}
+      {view === 'dashboard' && deck && (
         <>
           <Navbar
-            mode={mode}
-            setMode={setMode}
+            mode={view}
+            setMode={setView}
             theme={theme}
             toggleTheme={toggleTheme}
           />
-          {mode === 'flashcards' && <Flashcards deck={deck} />}
-          {mode === 'learn' && <Learn deck={deck} />}
-          {mode === 'test' && <Test deck={deck} />}
+          <Dashboard deck={deck} onSelectMode={setView} />
         </>
-      ) : (
-        <Importer onImported={setDeck} />
+      )}
+      {['flashcards', 'learn', 'test'].includes(view) && deck && (
+        <>
+          <Navbar
+            mode={view}
+            setMode={setView}
+            theme={theme}
+            toggleTheme={toggleTheme}
+          />
+          {view === 'flashcards' && <Flashcards deck={deck} />}
+          {view === 'learn' && <Learn deck={deck} />}
+          {view === 'test' && <Test deck={deck} />}
+        </>
       )}
     </main>
   );

--- a/src/importer/Importer.css
+++ b/src/importer/Importer.css
@@ -4,6 +4,10 @@
   gap: 1rem;
 }
 
+.importer input[type="file"] {
+  align-self: flex-start;
+}
+
 .importer textarea {
   width: 100%;
   border-radius: var(--radius);

--- a/src/importer/Importer.jsx
+++ b/src/importer/Importer.jsx
@@ -7,6 +7,20 @@ export default function Importer({ onImported }) {
   const [text, setText] = useState('');
   const [error, setError] = useState('');
 
+  const handleFile = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      setText(ev.target.result);
+      setError('');
+    };
+    reader.onerror = () => {
+      setError('Failed to read file');
+    };
+    reader.readAsText(file);
+  };
+
   const handleImport = () => {
     try {
       const deck = parseDeck(text);
@@ -22,6 +36,12 @@ export default function Importer({ onImported }) {
   return (
     <div className="importer">
       <h2>Import Deck (JSON or CSV)</h2>
+      <input
+        type="file"
+        accept=".json,.csv"
+        onChange={handleFile}
+        aria-label="Deck file"
+      />
       <textarea
         aria-label="Deck JSON or CSV"
         value={text}

--- a/src/ui/Dashboard.css
+++ b/src/ui/Dashboard.css
@@ -1,0 +1,10 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dashboard .actions {
+  display: flex;
+  gap: 1rem;
+}

--- a/src/ui/Dashboard.jsx
+++ b/src/ui/Dashboard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import './Dashboard.css';
+
+export default function Dashboard({ deck, onSelectMode }) {
+  return (
+    <div className="dashboard">
+      <h2>{deck.title}</h2>
+      <p>{deck.cards.length} cards</p>
+      <div className="actions">
+        <button onClick={() => onSelectMode('flashcards')}>Flashcards</button>
+        <button onClick={() => onSelectMode('learn')}>Learn</button>
+        <button onClick={() => onSelectMode('test')}>Test</button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/Landing.css
+++ b/src/ui/Landing.css
@@ -1,0 +1,6 @@
+.landing {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}

--- a/src/ui/Landing.jsx
+++ b/src/ui/Landing.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './Landing.css';
+
+export default function Landing({ onImport, hasDeck, onStart }) {
+  return (
+    <div className="landing">
+      <p>Welcome to the SC-200 Quiz app.</p>
+      <button onClick={onImport}>Import Deck</button>
+      {hasDeck && <button onClick={onStart}>Go to Dashboard</button>}
+    </div>
+  );
+}

--- a/src/ui/Navbar.jsx
+++ b/src/ui/Navbar.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { FlipHorizontal2, BookOpen, CheckCircle2, Sun, Moon } from 'lucide-react';
+import { Home, FlipHorizontal2, BookOpen, CheckCircle2, Sun, Moon } from 'lucide-react';
 
 export default function Navbar({ mode, setMode, theme, toggleTheme }) {
   const items = [
+    { id: 'dashboard', label: 'Dashboard', icon: <Home size={18} /> },
     { id: 'flashcards', label: 'Flashcards', icon: <FlipHorizontal2 size={18} /> },
     { id: 'learn', label: 'Learn', icon: <BookOpen size={18} /> },
     { id: 'test', label: 'Test', icon: <CheckCircle2 size={18} /> },


### PR DESCRIPTION
## Summary
- enable file uploads for deck importer
- add basic landing page and dashboard with navigation

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "lucide-react")*


------
https://chatgpt.com/codex/tasks/task_e_68c17fa29788832c9a8a84f224eced82